### PR TITLE
Moodle requires to use full path + plugin name

### DIFF
--- a/classes/form/settings_form.php
+++ b/classes/form/settings_form.php
@@ -162,5 +162,7 @@ class settings_form extends moodleform {
     
     //Custom validation should be added here
     function validation($data, $files){
+        $data->mauticurl = filter_var($data->mauticurl, FILTER_SANITIZE_URL);
+        return $data;
     }
 }

--- a/classes/lib/datalib.php
+++ b/classes/lib/datalib.php
@@ -19,6 +19,13 @@ class datalib {
     public function createformevent($data) {
         global $DB, $CFG;
 
+        // Validate and sanitize Mautic URL and form ID
+        $data->mauticurl = filter_var($data->mauticurl, FILTER_SANITIZE_URL);
+        if (!$data->mauticurl) {
+            throw new Exception('Invalid Mautic URL');
+        }
+        $data->mauticformid = (int) $data->mauticformid;
+
         $dataobject = $this->format_form_data($data);
         $eventid = $DB->insert_record($this->tableformevent, $dataobject['eventform'], $returnid = true, $bulk = false);
 
@@ -56,6 +63,13 @@ class datalib {
 
     public function updateformevent($data) {
         global $DB;
+
+        // Validate and sanitize Mautic URL and form ID
+        $data->mauticurl = filter_var($data->mauticurl, FILTER_SANITIZE_URL);
+        if (!$data->mauticurl) {
+            throw new Exception('Invalid Mautic URL');
+        }
+        $data->mauticformid = (int) $data->mauticformid;
         
         $dataobject = $this->format_form_data($data);
         $this->updateformdata($dataobject);

--- a/classes/mauticobserver.php
+++ b/classes/mauticobserver.php
@@ -9,6 +9,26 @@ use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Cookie\CookieJar;
 
+class MauticLogger {
+    public static function log_submission($message, $level = 'INFO', $context = []) {
+        global $CFG;
+        $logfile = $CFG->dataroot . '/mautic_integration.log';
+        $timestamp = date('Y-m-d H:i:s');
+
+        $logLine = "[$timestamp] [$level]";
+
+        if (!empty($context['userId'])) {
+            $logLine .= " User: {$context['userId']}";
+        }
+        if (!empty($context['formId'])) {
+            $logLine .= " Form: {$context['formId']}";
+        }
+
+        $logLine .= " $message\n";
+        file_put_contents($logfile, $logLine, FILE_APPEND);
+    }
+}
+
 class mauticobserver {
 
     public static function enrolusercourse($event) {
@@ -107,8 +127,10 @@ class mauticobserver {
             $response = $request_exception->getResponse();
             $message = $request_exception->getMessage();
             
-            return;
+            log_mautic_submission("Submission failed: " . $message, 'ERROR');
         }
+
+        log_mautic_submission("Submission successful", 'INFO');
     
     }
 }

--- a/lang/en/local_mautic.php
+++ b/lang/en/local_mautic.php
@@ -22,6 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+$string['pluginname'] = 'Moodle Mautic';
 $string['mauticurl'] = 'Mautic Url';
 $string['mauticurldesc'] = 'Please insert the URL of your mautic instalation.';
 $string['mauticurlvalidateerror'] = 'Please insert a valid full url, which starts with http:// or https://';

--- a/settings.php
+++ b/settings.php
@@ -2,7 +2,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-require_once('../config.php');
+require_once(dirname(__FILE__) . '/../../config.php');
 require_once('classes/form/settings_form.php');
 require_once('classes/lib/admin_setting_configurl.php');
 


### PR DESCRIPTION
- Issue in Moodle 4.0+ is caused by a missing full file path for including config.php.
- Added Plugin name, previously it showed [pluginname,local_mautic]